### PR TITLE
support taxonomies registered to multiple CPTs.

### DIFF
--- a/tc-custom-taxonomy-filter.php
+++ b/tc-custom-taxonomy-filter.php
@@ -46,17 +46,16 @@ function tc_ctf_restrict_manage_posts() {
 }
 
 // Get only the custom taxonomies associated with this post type
+function tc_ctf_exclude_builtin($tax){
+    return $tax->_builtin == false;
+}
+
+// Get only the custom taxonomies associated with this post type
 function tc_ctf_get_filters() {
     global $typenow;
 
-    $args = array(
-        'object_type'   => array( $typenow ),
-        '_builtin'      => false
-    );
-
-    $taxonomies = get_taxonomies( $args );
-
-    return $taxonomies;
+    $taxonomies = get_object_taxonomies($typenow, 'objects' );
+    return array_keys(array_filter($taxonomies, 'tc_ctf_exclude_builtin'));
 }
 
 // Now, actually filter out the posts based on the category, er, _custom taxonomy_ we chose


### PR DESCRIPTION
Fixes #3 Probably worth testing first, but it's working for me.

props @fcingolani: https://wordpress.org/support/topic/not-showing-taxonomies-associated-to-more-than-1-custom-post-type?replies=1
